### PR TITLE
flatpak: Add systemd services for automatic updates

### DIFF
--- a/files/system/flatpak-update.service
+++ b/files/system/flatpak-update.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Update Flatpaks
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/flatpak update --assumeyes --noninteractive --system
+ExecStart=/usr/bin/flatpak remove --assumeyes --noninteractive --system --unused

--- a/files/system/flatpak-update.timer
+++ b/files/system/flatpak-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update Flatpaks daily
+
+[Timer]
+OnBootSec=10m
+OnActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/files/user/flatpak-update.service
+++ b/files/user/flatpak-update.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Update Flatpaks
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/flatpak update --assumeyes --noninteractive --user
+ExecStart=/usr/bin/flatpak remove --assumeyes --noninteractive --user --unused

--- a/files/user/flatpak-update.timer
+++ b/files/user/flatpak-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update Flatpaks daily
+
+[Timer]
+OnBootSec=10m
+OnActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/package.yml
+++ b/package.yml
@@ -1,6 +1,6 @@
 name       : flatpak
 version    : 1.14.4
-release    : 66
+release    : 67
 source     :
     - https://github.com/flatpak/flatpak/releases/download/1.14.4/flatpak-1.14.4.tar.xz : 8a34dbd0b67c434e7598b98ec690953d046f0db26e480aeafb46d72aec716799
 homepage   : https://flatpak.org/
@@ -50,3 +50,7 @@ install    : |
 
     # Add tmpfiles
     install -Dm00644 $pkgfiles/flatpak.tmpfiles $installdir/%libdir%/tmpfiles.d/flatpak.conf
+
+    # Add auto-update systemd services
+    install -Dm00644 -t $installdir/%libdir%/systemd/system $pkgfiles/system/flatpak-update.{service,timer}
+    install -Dm00644 -t $installdir/%libdir%/systemd/user $pkgfiles/user/flatpak-update.{service,timer}

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>flatpak</Name>
         <Homepage>https://flatpak.org/</Homepage>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Packager>
         <License>LGPL-2.1-or-later</License>
         <PartOf>desktop</PartOf>
@@ -39,6 +39,10 @@
             <Path fileType="library">/usr/lib64/girepository-1.0/Flatpak-1.0.typelib</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0</Path>
             <Path fileType="library">/usr/lib64/libflatpak.so.0.11404.0</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/system/flatpak-update.timer</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.service</Path>
+            <Path fileType="library">/usr/lib64/systemd/user/flatpak-update.timer</Path>
             <Path fileType="library">/usr/lib64/sysusers.d/flatpak.conf</Path>
             <Path fileType="library">/usr/lib64/tmpfiles.d/flatpak.conf</Path>
             <Path fileType="data">/usr/share/bash-completion/completions/flatpak</Path>
@@ -144,7 +148,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="66">flatpak</Dependency>
+            <Dependency release="67">flatpak</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/flatpak/flatpak-bundle-ref.h</Path>
@@ -212,12 +216,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="66">
-            <Date>2023-08-11</Date>
+        <Update release="67">
+            <Date>2023-09-12</Date>
             <Version>1.14.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
### Summary

Add Systemd services and timers for automatic Flatpak updates. The update intervals have been chosen to match the Snaps (4 times a day). The reason for inclusion is that Flatpak includes no automated update mechanism and users are not notified of updates via the software center. Additionally, this ensures that users switching from Snap to Flatpak do not have to lose automated updates. Note that Flatpaks can safely be updated while running.

### Test Plan

```sh
systemctl enable --user flatpak-update.timer
sudo systemctl enable flatpak-update.timer
```

See that Flatpaks are automatically updated.

### Checklist

- [x] Package was built and tested against unstable
